### PR TITLE
Add Go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/yext/terraform-inventory
+
+go 1.15
+
+require (
+	github.com/adammck/venv v0.0.0-20200610172036-e77789703e7c
+	github.com/blang/vfs v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/adammck/venv v0.0.0-20200610172036-e77789703e7c h1:RoL0r3mR3JSkLur8q8AD59cByJ+kRwJHODNimZBd7GI=
+github.com/adammck/venv v0.0.0-20200610172036-e77789703e7c/go.mod h1:3zXR2a/VSQndtpShh783rUTaEA2mpqN2VqZclBARBc0=
+github.com/blang/vfs v1.0.0 h1:AUZUgulCDzbaNjTRWEP45X7m/J10brAptZpSRKRZBZc=
+github.com/blang/vfs v1.0.0/go.mod h1:jjuNUc/IKcRNNWC9NUCvz4fR9PZLPIKxEygtPs/4tSI=


### PR DESCRIPTION
Performed via:

```
GO111MODULE=on GOPATH= go mod init github.com/yext/terraform-inventory
GO111MODULE=on GOPATH= go get
```